### PR TITLE
Core/AuctionHouse: Fix overflow in item ordering.

### DIFF
--- a/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -261,7 +261,7 @@ public:
     {
         for (std::size_t i = 0; i < _sortCount; ++i)
         {
-            int32 ordering = CompareColumns(_sorts[i].SortOrder, left, right);
+            int64 ordering = CompareColumns(_sorts[i].SortOrder, left, right);
             if (ordering != 0)
                 return (ordering < 0) == !_sorts[i].ReverseSort;
         }
@@ -270,7 +270,7 @@ public:
     }
 
 private:
-    int32 CompareColumns(AuctionHouseSortOrder column, AuctionsBucketData const* left, AuctionsBucketData const* right) const
+    int64 CompareColumns(AuctionHouseSortOrder column, AuctionsBucketData const* left, AuctionsBucketData const* right) const
     {
         switch (column)
         {
@@ -304,7 +304,7 @@ public:
     {
         for (std::size_t i = 0; i < _sortCount; ++i)
         {
-            int32 ordering = CompareColumns(_sorts[i].SortOrder, left, right);
+            int64 ordering = CompareColumns(_sorts[i].SortOrder, left, right);
             if (ordering != 0)
                 return (ordering < 0) == !_sorts[i].ReverseSort;
         }
@@ -317,7 +317,7 @@ public:
     }
 
 private:
-    int32 CompareColumns(AuctionHouseSortOrder column, AuctionPosting const* left, AuctionPosting const* right) const
+    int64 CompareColumns(AuctionHouseSortOrder column, AuctionPosting const* left, AuctionPosting const* right) const
     {
         switch (column)
         {


### PR DESCRIPTION
**Changes proposed:**

-  Fixes the overflow in item ordering as seen here:

![image](https://user-images.githubusercontent.com/17987686/109817495-47d0b000-7c32-11eb-86ee-2b50edd80f0c.png)


**Target branch(es):** 
- [ ] 3.3.5
- [x] master

**Tests performed:** (Does it build, tested in-game, etc.)
- [x] Builds
- [x] Tested In-game